### PR TITLE
Catalog card buttons improvement

### DIFF
--- a/client/src/components/Cards/CatalogCard.tsx
+++ b/client/src/components/Cards/CatalogCard.tsx
@@ -90,10 +90,24 @@ type TcatalogCard = {
    image?: string;
    productCount: number;
 };
-const menuOptions: { id: string; content: string }[] = [
-   { id: 'edit', content: 'Edit catalog' },
-   { id: 'duplicate', content: 'Duplicate catalog' },
-   { id: 'remove', content: 'Remove catalog' },
+const menuOptions: { id: string; content: string; optionDesc?: string }[] = [
+   { id: 'edit', content: 'Edit catalog', optionDesc: 'Edit the catalog name' },
+   {
+      id: 'duplicate',
+      content: 'Duplicate catalog',
+      optionDesc: 'Duplicate the current catalog and all its products',
+   },
+   {
+      id: 'copy link',
+      content: 'Copy upload link',
+      optionDesc: 'Copy the catalog link to upload products',
+   },
+   { id: 'copy key', content: 'Copy catalog key', optionDesc: 'Copy the catalog id' },
+   {
+      id: 'remove',
+      content: 'Remove catalog',
+      optionDesc: 'Delete the catalog and all its content permanently',
+   },
 ];
 
 export default function CatalogCard({ id, name, products, createdAt, productCount }: TcatalogCard) {
@@ -117,60 +131,80 @@ export default function CatalogCard({ id, name, products, createdAt, productCoun
    };
    const date = createdAt ? new Date(createdAt).toLocaleString() : 'no date';
    const defaultImage = products?.[0]?.image;
+   let renderDialog: any;
 
-   const renderDialog =
-      option === 'edit' ? (
-         <FormCreator
-            onModalChange={handleClose}
-            isOpen={true}
-            apiFunction={updateCatalog}
-            initialValues={{ id, name }}
-            keysToInvalidate={['catalogs']}
-            acceptBtnName="Update"
-            extraFn={(data) => {
-               setNotifications({
-                  type: 'Update',
-                  content: data,
-                  timestamp: new Date().toISOString(),
-               });
-            }}
-         />
-      ) : option === 'remove' ? (
-         <CustomDialog
-            isOpen={Boolean(option)}
-            onModalChange={handleClose}
-            onAccept={() => removeCatalog({ id })}
-            queryKey={['catalogs']}
-            action="Remove"
-         >
-            <Typography variant="h6">
-               You are about to delete the catalog "<b>{name}</b>". Are you sure?
-            </Typography>
-            <CustomAlert
-               message="This action can't be undone."
-               alertType="error"
-               variant="filled"
+   switch (option) {
+      case 'edit':
+         renderDialog = (
+            <FormCreator
+               onModalChange={handleClose}
+               isOpen={true}
+               apiFunction={updateCatalog}
+               initialValues={{ id, name }}
+               keysToInvalidate={['catalogs']}
+               acceptBtnName="Update"
+               extraFn={(data) => {
+                  setNotifications({
+                     type: 'Update',
+                     content: data,
+                     timestamp: new Date().toISOString(),
+                  });
+               }}
             />
-         </CustomDialog>
-      ) : option === 'duplicate' ? (
-         <CustomDialog
-            isOpen={Boolean(option)}
-            onModalChange={handleClose}
-            onAccept={() => clonedCatalog(id)}
-            queryKey={['catalogs']}
-            action="Duplicate"
-         >
-            <Typography variant="h6">
-               You are about to duplicate the catalog "<b>{name}</b>". Are you sure?
-            </Typography>
-            <CustomAlert
-               message="The catalog and all its products will be duplicated"
-               alertType="info"
-               variant="standard"
-               propClassName={classes.alertStyle}
-            />
-         </CustomDialog>
-      ) : null;
+         );
+         break;
+      case 'remove':
+         renderDialog = (
+            <CustomDialog
+               isOpen={Boolean(option)}
+               onModalChange={handleClose}
+               onAccept={() => removeCatalog({ id })}
+               queryKey={['catalogs']}
+               action="Remove"
+            >
+               <Typography variant="h6">
+                  You are about to delete the catalog "<b>{name}</b>". Are you sure?
+               </Typography>
+               <CustomAlert
+                  message="This action can't be undone."
+                  alertType="error"
+                  variant="filled"
+               />
+            </CustomDialog>
+         );
+         break;
+      case 'duplicate':
+         renderDialog = (
+            <CustomDialog
+               isOpen={Boolean(option)}
+               onModalChange={handleClose}
+               onAccept={() => clonedCatalog(id)}
+               queryKey={['catalogs']}
+               action="Duplicate"
+            >
+               <Typography variant="h6">
+                  You are about to duplicate the catalog "<b>{name}</b>". Are you sure?
+               </Typography>
+               <CustomAlert
+                  message="The catalog and all its products will be duplicated"
+                  alertType="info"
+                  variant="standard"
+                  propClassName={classes.alertStyle}
+               />
+            </CustomDialog>
+         );
+         break;
+      case 'copy link':
+         alert(option);
+         break;
+      case 'copy key':
+         alert(option);
+         break;
+
+      default:
+         renderDialog = null;
+         break;
+   }
 
    return (
       <>

--- a/client/src/components/Cards/CatalogCard.tsx
+++ b/client/src/components/Cards/CatalogCard.tsx
@@ -25,6 +25,8 @@ import classNames from 'classnames';
 import React from 'react';
 import { useStore } from '../../pages/DrawerAppbar';
 import PopOverList from '../PopOverList';
+import { useCopyToClipboard } from '../../hooks';
+import CustomSnackBar from '../CustomSnackbar';
 
 const useStyles = makeStyles((theme) =>
    createStyles({
@@ -114,6 +116,9 @@ export default function CatalogCard({ id, name, products, createdAt, productCoun
    const classes = useStyles();
    const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
    const [option, setOption] = useState<any>(null);
+   const [snackMessage, setSnackMessage] = useState('');
+   const [isCopied, copyToClipboardFn] = useCopyToClipboard();
+
    const history = useHistory();
    const { setNotifications } = useStore();
 
@@ -131,6 +136,15 @@ export default function CatalogCard({ id, name, products, createdAt, productCoun
    };
    const date = createdAt ? new Date(createdAt).toLocaleString() : 'no date';
    const defaultImage = products?.[0]?.image;
+
+   let RenderSnackBar = (
+      <CustomSnackBar
+         message={snackMessage}
+         open={isCopied}
+         alertType="success"
+         onClose={handleClose}
+      />
+   );
    let renderDialog: any;
 
    switch (option) {
@@ -195,10 +209,17 @@ export default function CatalogCard({ id, name, products, createdAt, productCoun
          );
          break;
       case 'copy link':
-         alert(option);
+         const uploadUrl = `${window.location.href}/${id}/upload`;
+         copyToClipboardFn(uploadUrl).then(() => {
+            setSnackMessage('Catalog upload products link copied successfully');
+            handleClose();
+         });
          break;
       case 'copy key':
-         alert(option);
+         copyToClipboardFn(id).then(() => {
+            setSnackMessage('Catalog key copied successfully');
+            handleClose();
+         });
          break;
 
       default:
@@ -264,6 +285,7 @@ export default function CatalogCard({ id, name, products, createdAt, productCoun
             </CardContent>
          </Card>
          {renderDialog}
+         {RenderSnackBar}
       </>
    );
 }

--- a/client/src/components/PopOverList.tsx
+++ b/client/src/components/PopOverList.tsx
@@ -1,4 +1,12 @@
-import { makeStyles, MenuItem, MenuList, Popover, Theme, Typography } from '@material-ui/core';
+import {
+   makeStyles,
+   MenuItem,
+   MenuList,
+   Popover,
+   Theme,
+   Tooltip,
+   Typography,
+} from '@material-ui/core';
 import React from 'react';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -15,7 +23,7 @@ const useStyles = makeStyles((theme: Theme) => ({
    },
 }));
 type PopOverProps = {
-   options: { id: string; content: string; disabled?: boolean; icon?: any }[];
+   options: { id: string; content: string; disabled?: boolean; icon?: any; optionDesc?: string }[];
    buttonTarget: HTMLButtonElement | null;
    setButtonTarget: (value: any) => any;
    setCurrentOption: (currentOption: string | null) => any;
@@ -50,16 +58,17 @@ export default function PopOverList({
             }}
          >
             <MenuList>
-               {options.map(({ id, content, disabled, icon }) => (
-                  <MenuItem
-                     key={id}
-                     alignItems="center"
-                     onClick={() => handleOption(id)}
-                     disabled={disabled}
-                  >
-                     {icon && <span className={classes.icons}>{icon}</span>}
-                     <Typography className={classes.typographyButtons}>{content}</Typography>
-                  </MenuItem>
+               {options.map(({ id, content, disabled, icon, optionDesc = '' }) => (
+                  <Tooltip key={id} title={optionDesc} placement="top-start" enterDelay={1000}>
+                     <MenuItem
+                        alignItems="center"
+                        onClick={() => handleOption(id)}
+                        disabled={disabled}
+                     >
+                        {icon && <span className={classes.icons}>{icon}</span>}
+                        <Typography className={classes.typographyButtons}>{content}</Typography>
+                     </MenuItem>
+                  </Tooltip>
                ))}
             </MenuList>
          </Popover>

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,5 +1,30 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation } from '@tanstack/react-query';
+import { useState, useEffect } from 'react';
+
+type CopyToClipProps = [isCopied: boolean, copyToClipboard: (text: string) => Promise<any>];
 
 export function useMutateHook(apiFunction: () => any) {
-  return useMutation(apiFunction);
+   return useMutation(apiFunction);
+}
+
+export function useCopyToClipboard() {
+   const [isCopied, setIsCopied] = useState(false);
+
+   useEffect(() => {
+      if (isCopied) {
+         const timeoutId = setTimeout(() => {
+            setIsCopied(false);
+         }, 2000);
+
+         return () => {
+            clearTimeout(timeoutId);
+         };
+      }
+   }, [isCopied]);
+
+   const copyToClipboard: (text: string) => void = (text = '') => {
+      return navigator.clipboard.writeText(text).then(() => setIsCopied(true));
+   };
+
+   return [isCopied, copyToClipboard] as CopyToClipProps;
 }


### PR DESCRIPTION
News: 
 - Two additional options have been added : `Copy upload link` and `Copy catalog key`
 - Now each button has a tooltip which displays a brief description of the action such a button executes
 
Before:
![image](https://user-images.githubusercontent.com/81488669/229145107-ece6ecbf-03c5-4a7c-a57e-b70bbeb3fdc8.png)

After:

![image](https://user-images.githubusercontent.com/81488669/229145935-daefbac5-6160-4c44-85eb-58396e1fe359.png)

